### PR TITLE
feature #75 MKL on Windows 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 tests_all.xml
 tests_minimal.xml
 /$tf
+/bin/*/mkl
+/bin/*/openblas
 /bin/win32/qml
 /bin/win32/plugins
 /bin/x64/qml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Features:
+---------
+
+  [#75](http://github.com/Nelson-numerical-software/nelson/issues/75): Intel Math Kernel Library can used to replace OpenBLAS and FFTW.
+
+
 ## 0.1.10 alpha (2017-10-29)
 
 Features:

--- a/bin/bin.iss
+++ b/bin/bin.iss
@@ -65,3 +65,11 @@ Source: {#RootPath}bin\{#BinPath}\libmmd.dll; DestDir: {app}\bin\{#BinPath}\
 ;==============================================================================
 Source: {#RootPath}bin\{#BinPath}\LICENSE_1_0.txt; DestDir: {app}\bin\{#BinPath}\;
 ;==============================================================================
+; used by linear_algebra and slicot modules
+#ifdef NELSON_X64
+Source: {#RootPath}bin\{#BinPath}\libgcc_s_seh-1.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\libgfortran-3.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\libquadmath-0.dll; DestDir: {app}\bin\{#BinPath}\;
+#endif
+Source: {#RootPath}bin\{#BinPath}\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\;
+;==============================================================================

--- a/bin/bin.iss
+++ b/bin/bin.iss
@@ -67,9 +67,28 @@ Source: {#RootPath}bin\{#BinPath}\LICENSE_1_0.txt; DestDir: {app}\bin\{#BinPath}
 ;==============================================================================
 ; used by linear_algebra and slicot modules
 #ifdef NELSON_X64
-Source: {#RootPath}bin\{#BinPath}\libgcc_s_seh-1.dll; DestDir: {app}\bin\{#BinPath}\;
-Source: {#RootPath}bin\{#BinPath}\libgfortran-3.dll; DestDir: {app}\bin\{#BinPath}\;
-Source: {#RootPath}bin\{#BinPath}\libquadmath-0.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\openblas\libgcc_s_seh-1.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\openblas\libgfortran-3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\openblas\libquadmath-0.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
 #endif
-Source: {#RootPath}bin\{#BinPath}\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\openblas\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
+;==============================================================================
+Source: {#RootPath}bin\{#BinPath}\mkl\libiomp5md.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_avx.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_avx2.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_avx512.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_core.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_intel_thread.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_license.txt; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_rt.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+#ifdef NELSON_X64
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_avx512_mic.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_mc.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_mc3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+#else
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_p4.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_p4m.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\mkl_p4m3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+#endif
 ;==============================================================================

--- a/modules/fftw/module.iss
+++ b/modules/fftw/module.iss
@@ -18,8 +18,11 @@
 ;==============================================================================
 #define MODULE_NAME "fftw"
 ;==============================================================================
-Source: {#RootPath}bin\{#BinPath}\libfftw3f-3.dll; DestDir: {app}\bin\{#BinPath}\;
-Source: {#RootPath}bin\{#BinPath}\libfftw3-3.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\fftw\libfftw3f-3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\fftw\libfftw3-3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_DEFAULT_CPU_LIBRARY}
+;==============================================================================
+Source: {#RootPath}bin\{#BinPath}\mkl\libfftw3f-3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
+Source: {#RootPath}bin\{#BinPath}\mkl\libfftw3-3.dll; DestDir: {app}\bin\{#BinPath}\; Components: {#COMPONENT_MKL_CPU_LIBRARY}
 ;==============================================================================
 Source: {#RootPath}bin\{#BinPath}\libnlsFftw.dll; DestDir: {app}\bin\{#BinPath}\;
 Source: {#RootPath}bin\{#BinPath}\libnlsFftw_builtin.dll; DestDir: {app}\bin\{#BinPath}\;

--- a/modules/linear_algebra/module.iss
+++ b/modules/linear_algebra/module.iss
@@ -20,12 +20,6 @@
 ;==============================================================================
 Source: {#RootPath}bin\{#BinPath}\libnlsLinear_algebra.dll; DestDir: {app}\bin\{#BinPath}\;
 Source: {#RootPath}bin\{#BinPath}\libnlsLinear_algebra_builtin.dll; DestDir: {app}\bin\{#BinPath}\;
-#ifdef NELSON_X64
-Source: {#RootPath}bin\{#BinPath}\libgcc_s_seh-1.dll; DestDir: {app}\bin\{#BinPath}\;
-Source: {#RootPath}bin\{#BinPath}\libgfortran-3.dll; DestDir: {app}\bin\{#BinPath}\;
-Source: {#RootPath}bin\{#BinPath}\libquadmath-0.dll; DestDir: {app}\bin\{#BinPath}\;
-#endif
-Source: {#RootPath}bin\{#BinPath}\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\;
 ;==============================================================================
 Source: {#RootPath}modules\{#MODULE_NAME}\loader.nls; DestDir: {app}\modules\{#MODULE_NAME}\;
 Source: {#RootPath}modules\{#MODULE_NAME}\etc\startup.nls; DestDir: {app}\modules\{#MODULE_NAME}\etc\;

--- a/modules/linear_algebra/module.iss
+++ b/modules/linear_algebra/module.iss
@@ -25,7 +25,7 @@ Source: {#RootPath}bin\{#BinPath}\libgcc_s_seh-1.dll; DestDir: {app}\bin\{#BinPa
 Source: {#RootPath}bin\{#BinPath}\libgfortran-3.dll; DestDir: {app}\bin\{#BinPath}\;
 Source: {#RootPath}bin\{#BinPath}\libquadmath-0.dll; DestDir: {app}\bin\{#BinPath}\;
 #endif
-Source: {#RootPath}bin\{#BinPath}\libopenblas.dll; DestDir: {app}\bin\{#BinPath}\;
+Source: {#RootPath}bin\{#BinPath}\libnlsblaslapack.dll; DestDir: {app}\bin\{#BinPath}\;
 ;==============================================================================
 Source: {#RootPath}modules\{#MODULE_NAME}\loader.nls; DestDir: {app}\modules\{#MODULE_NAME}\;
 Source: {#RootPath}modules\{#MODULE_NAME}\etc\startup.nls; DestDir: {app}\modules\{#MODULE_NAME}\etc\;

--- a/modules/linear_algebra/src/c/dllMain.c
+++ b/modules/linear_algebra/src/c/dllMain.c
@@ -18,7 +18,7 @@
 //=============================================================================
 #include <Windows.h>
 //=============================================================================
-#pragma comment(lib, "libopenblas.lib")
+#pragma comment(lib, "libnlsblaslapack.lib")
 //=============================================================================
 int WINAPI DllMain(HINSTANCE hInstance, DWORD reason, PVOID pvReserved)
 {

--- a/modules/slicot/src/c/dllMain.c
+++ b/modules/slicot/src/c/dllMain.c
@@ -27,7 +27,7 @@
 #pragma comment(lib, "boost_filesystem-vc141-mt-1_64.lib")
 #endif
 //=============================================================================
-#pragma comment(lib, "libopenblas.lib")
+#pragma comment(lib, "libnlsblaslapack.lib")
 //=============================================================================
 int WINAPI DllMain(HINSTANCE hInstance, DWORD reason, PVOID pvReserved)
 {

--- a/tools/innosetup/Nelson.iss
+++ b/tools/innosetup/Nelson.iss
@@ -22,7 +22,7 @@
 #define NELSON_X64
 #define NELSON_DEBUG
 #define CURRENT_YEAR "2017"
-#define APPLICATION_VERSION "0.0.1.0"
+#define APPLICATION_VERSION "0.1.11.0"
 #endif
 #define APPLICATION_NAME "Nelson"
 #define APPLICATION_EXE_GUI_NAME "Nelson-gui.exe"
@@ -47,6 +47,12 @@
 ;==============================================================================
 [Languages]
 #include "languages.iss"
+;==============================================================================
+[CustomMessages]
+#include "custommessages.iss"
+;==============================================================================
+[Components]
+#include "components.iss"
 ;==============================================================================
 [Tasks]
 #include "tasks.iss"

--- a/tools/innosetup/components.iss
+++ b/tools/innosetup/components.iss
@@ -1,0 +1,29 @@
+;==============================================================================
+; Copyright (c) 2016-2017 Allan CORNET (Nelson)
+;==============================================================================
+; LICENCE_BLOCK_BEGIN
+; This program is free software: you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation, either version 2 of the License, or
+; (at your option) any later version.
+; 
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+; 
+; You should have received a copy of the GNU General Public License
+; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+; LICENCE_BLOCK_END
+;==============================================================================
+#define COMPONENT_NELSON 'Nelson'
+Name: {#COMPONENT_NELSON}; Description: Nelson {#APPLICATION_VERSION}; Types: full compact custom; Flags: fixed;
+;
+#define COMPONENT_CPU_OPTIMIZATION 'CPU_OPTIMIZATION'
+#define COMPONENT_MKL_CPU_LIBRARY 'CPU_OPTIMIZATION\MKL'
+#define COMPONENT_DEFAULT_CPU_LIBRARY 'CPU_OPTIMIZATION\DEFAULT'
+;
+Name: {#COMPONENT_CPU_OPTIMIZATION}; Description:{cm:CPU_OPTIMIZATION_FOR_NELSON}; Types: full compact custom; Flags: fixed;
+Name: {#COMPONENT_MKL_CPU_LIBRARY}; Description:{cm:MKL_LIBRARIES}; Flags: exclusive
+Name: {#COMPONENT_DEFAULT_CPU_LIBRARY}; Description:{cm:DEFAULT_LIBRARIES}; Flags: exclusive
+;==============================================================================

--- a/tools/innosetup/custommessages.iss
+++ b/tools/innosetup/custommessages.iss
@@ -1,0 +1,21 @@
+;==============================================================================
+; Copyright (c) 2016-2017 Allan CORNET (Nelson)
+;==============================================================================
+; LICENCE_BLOCK_BEGIN
+; This program is free software: you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation, either version 2 of the License, or
+; (at your option) any later version.
+; 
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+; 
+; You should have received a copy of the GNU General Public License
+; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+; LICENCE_BLOCK_END
+;==============================================================================
+#include "english_messages_nelson.isl"
+#include "french_messages_nelson.isl"
+;==============================================================================

--- a/tools/innosetup/english_messages_nelson.isl
+++ b/tools/innosetup/english_messages_nelson.isl
@@ -1,0 +1,24 @@
+;==============================================================================
+; Copyright (c) 2016-2017 Allan CORNET (Nelson)
+;==============================================================================
+; LICENCE_BLOCK_BEGIN
+; This program is free software: you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation, either version 2 of the License, or
+; (at your option) any later version.
+; 
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+; 
+; You should have received a copy of the GNU General Public License
+; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+; LICENCE_BLOCK_END
+;==============================================================================
+english.LANGUAGE = english
+;
+english.CPU_OPTIMIZATION_FOR_NELSON = Optimisation CPU pour Nelson
+english.DEFAULT_LIBRARIES = BLAS, LAPACK, FFTW Reference libraries for Nelson
+english.MKL_LIBRARIES = MKL Library (BLAS, LAPACK, FFTW wrappers) for Nelson
+;==============================================================================

--- a/tools/innosetup/french_messages_nelson.isl
+++ b/tools/innosetup/french_messages_nelson.isl
@@ -1,0 +1,24 @@
+;==============================================================================
+; Copyright (c) 2016-2017 Allan CORNET (Nelson)
+;==============================================================================
+; LICENCE_BLOCK_BEGIN
+; This program is free software: you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation, either version 2 of the License, or
+; (at your option) any later version.
+; 
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+; 
+; You should have received a copy of the GNU General Public License
+; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+; LICENCE_BLOCK_END
+;==============================================================================
+french.LANGUAGE = Français
+;
+french.CPU_OPTIMIZATION_FOR_NELSON = Optimisation CPU pour Nelson
+french.DEFAULT_LIBRARIES = Bibliothèques de reference BLAS, LAPACK, FFTW pour Nelson
+french.MKL_LIBRARIES = Bibliothèque MKL (BLAS, LAPACK, FFTW wrappers) pour Nelson
+;==============================================================================


### PR DESCRIPTION
Intel Math Kernel Library can used to replace OpenBLAS and FFTW.
Users can choose to use MKL or default librairies at setup 
