### PR TITLE
Dark theme detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - French translations imported from Weblate (Thanks to contributors)
 
+- Dark theme detected and applied on Linux, MacOS and Windows.
+
 ### Fixed
 
 - Main Nelson's font was not applied on some OS platforms (ex: MacOS Catalina)

--- a/modules/graphics/builtin/c/nlsGraphics_builtin.vcxproj
+++ b/modules/graphics/builtin/c/nlsGraphics_builtin.vcxproj
@@ -100,6 +100,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,6 +144,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +169,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/graphics/src/c/nlsGraphics.vcxproj
+++ b/modules/graphics/src/c/nlsGraphics.vcxproj
@@ -200,6 +200,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)modules/graphics/src/include;$(SolutionDir)modules/gui/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/modules_manager/src/include;$(SolutionDir)modules/characters_encoding/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/files_folders_functions/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Eigen;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost;$(QTDIR)/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -224,6 +225,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)modules/graphics/src/include;$(SolutionDir)modules/gui/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/modules_manager/src/include;$(SolutionDir)modules/characters_encoding/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/files_folders_functions/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Eigen;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost;$(QTDIR)/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -250,6 +252,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)modules/graphics/src/include;$(SolutionDir)modules/gui/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/modules_manager/src/include;$(SolutionDir)modules/characters_encoding/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/files_folders_functions/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Eigen;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost;$(QTDIR)/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -278,6 +281,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)modules/graphics/src/include;$(SolutionDir)modules/gui/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/modules_manager/src/include;$(SolutionDir)modules/characters_encoding/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/files_folders_functions/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Eigen;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost;$(QTDIR)/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/gui/builtin/c/nlsGui_builtin.vcxproj
+++ b/modules/gui/builtin/c/nlsGui_builtin.vcxproj
@@ -100,6 +100,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,6 +144,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +169,7 @@
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/gui/src/c/nlsGui.vcxproj
+++ b/modules/gui/src/c/nlsGui.vcxproj
@@ -210,6 +210,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -235,6 +236,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -262,6 +264,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -291,6 +294,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/gui/src/cpp/MainGuiObject.cpp
+++ b/modules/gui/src/cpp/MainGuiObject.cpp
@@ -100,9 +100,7 @@ InitGuiObjects(void)
     qInstallMessageHandler(QtMessageOutput);
     if (NelSonQtApp == nullptr) {
         NelSonQtApp = new QApplication(argc, argv);
-        if (NelSonQtApp) {
-            createNelsonPalette(NelSonQtApp->palette());
-        }
+        createNelsonPalette();
         QCoreApplication::setApplicationName("Nelson");
         QCoreApplication::setOrganizationDomain(
             "https://nelson-numerical-software.github.io/nelson-website/");

--- a/modules/gui/src/cpp/NelsonColors.cpp
+++ b/modules/gui/src/cpp/NelsonColors.cpp
@@ -31,13 +31,13 @@ namespace Nelson {
 QColor
 getWarningColor()
 {
-    return QColor(Qt::darkYellow);
+    return QColor(QColor(255, 175, 0));
 }
 //===================================================================================
 QColor
 getInputColor()
 {
-    return QColor(Qt::blue);
+    return isDarkPalette() ? QColor(Qt::cyan) : QColor(Qt::blue);
 }
 //===================================================================================
 QColor

--- a/modules/gui/src/cpp/NelsonPalette.cpp
+++ b/modules/gui/src/cpp/NelsonPalette.cpp
@@ -23,36 +23,74 @@
 // License along with this program. If not, see <http://www.gnu.org/licenses/>.
 // LICENCE_BLOCK_END
 //=============================================================================
+#include <QtWidgets/QApplication>
+#if _MSC_VER
 #include <QtCore/QSettings>
+#endif
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QToolTip>
+#include <QtWidgets/QStyleFactory>
 #include "NelsonPalette.hpp"
 //===================================================================================
 namespace Nelson {
 //===================================================================================
-static QPalette initialePalette;
 static QPalette nelsonPalette;
-static bool isDarkMode = false;
+static bool isQtDarkMode = false;
+//===================================================================================
+static void
+changeToDarkTheme()
+{
+    nelsonPalette.setColor(QPalette::Window, QColor(53, 53, 53));
+    nelsonPalette.setColor(QPalette::WindowText, Qt::white);
+    nelsonPalette.setColor(QPalette::Base, QColor(30, 30, 30));
+    nelsonPalette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+    nelsonPalette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
+    nelsonPalette.setColor(QPalette::ToolTipText, Qt::white);
+    nelsonPalette.setColor(QPalette::Text, Qt::white);
+    nelsonPalette.setColor(QPalette::Button, QColor(53, 53, 53));
+    nelsonPalette.setColor(QPalette::ButtonText, Qt::white);
+    nelsonPalette.setColor(QPalette::BrightText, Qt::red);
+    nelsonPalette.setColor(QPalette::Link, QColor(42, 130, 218));
+    nelsonPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    nelsonPalette.setColor(QPalette::HighlightedText, Qt::black);
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::Text, QColor(164, 166, 168));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(164, 166, 168));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(164, 166, 168));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(164, 166, 168));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::Base, QColor(68, 68, 68));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::Window, QColor(68, 68, 68));
+    nelsonPalette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(68, 68, 68));
+    qApp->setStyle(QStyleFactory::create("Fusion"));
+    QToolTip::setPalette(nelsonPalette);
+    qApp->setPalette(nelsonPalette);
+    qApp->setStyleSheet(
+        "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+}
 //===================================================================================
 void
-createNelsonPalette(QPalette qDefaultPalette)
+createNelsonPalette()
 {
-    // Currently, only macos can correctly manage dark mode with Qt without tricks ...
-    initialePalette = qDefaultPalette;
-    nelsonPalette = initialePalette;
-#ifdef _MSC_VER
-    /*
-    QSettings settings(
-        "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-        QSettings::NativeFormat);
-    isDarkMode = settings.value("AppsUseLightTheme") == 0;
-    */
-#else
+    nelsonPalette = qApp->palette();
+    QColor windowTextColor =nelsonPalette.color(QPalette::WindowText);
+    QColor windowColor = nelsonPalette.color(QPalette::Window);
+    isQtDarkMode = windowTextColor.toHsl().value() > windowColor.toHsl().value();
+    // Qt 5 and Qt6 currently does not manage natevily dark theme on Windows ...
+    if (!isQtDarkMode) {
+#if _MSC_VER
+        QSettings settings(
+            "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            QSettings::NativeFormat);
+        isQtDarkMode = (settings.value("AppsUseLightTheme") == 0);
+        if (isQtDarkMode) {
+            changeToDarkTheme();
+        }
+#endif
 #ifdef __APPLE__
-    QColor baseActiveColor = initialePalette.color(QPalette::Active, QPalette::Base);
-    QColor defaultDarkColorMacos(30, 30, 30, 255);
-    isDarkMode = baseActiveColor == defaultDarkColorMacos;
-#else
+        QColor baseActiveColor = nelsonPalette.color(QPalette::Active, QPalette::Base);
+        QColor defaultDarkColorMacos(30, 30, 30, 255);
+        isQtDarkMode = baseActiveColor == defaultDarkColorMacos;
 #endif
-#endif
+    }
 }
 //===================================================================================
 QPalette
@@ -64,7 +102,7 @@ getNelsonPalette()
 bool
 isDarkPalette()
 {
-    return isDarkMode;
+    return isQtDarkMode;
 }
 //===================================================================================
 }

--- a/modules/gui/src/cpp/QtTerminal.cpp
+++ b/modules/gui/src/cpp/QtTerminal.cpp
@@ -298,11 +298,28 @@ QtTerminal::clearTerminal()
     }
 }
 //=============================================================================
+void
+QtTerminal::ensureInputColor()
+{
+    // force to restore input color
+    if (isInEditionZone()) {
+        QTextCursor cur = textCursor();
+        setTextColor(getInputColor());
+        QTextCharFormat fmt;
+        fmt.setForeground(getInputColor());
+        cur.setCharFormat(fmt);
+        cur.setCharFormat(QTextCharFormat());
+        setTextCursor(cur);
+    }
+}
+//=============================================================================
 bool
 QtTerminal::handlePreviousCharKeyPress()
 {
     QTextCursor cur = textCursor();
     const int col = cur.columnNumber();
+    ensureInputColor();
+
     if ((promptBlock == cur.block()) && (col == mPrompt.size())) {
         return true;
     }
@@ -387,6 +404,7 @@ QtTerminal::keyPressEvent(QKeyEvent* event)
         if (!isInEditionZone()) {
             return;
         }
+        ensureInputColor();
     } else if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
         if (isInEditionZone()) {
             QString cmd = getCurrentCommandLine();

--- a/modules/gui/src/cpp/QtTerminal.h
+++ b/modules/gui/src/cpp/QtTerminal.h
@@ -118,6 +118,9 @@ private:
     bool
     updateHistoryToken();
 
+    void
+    ensureInputColor();
+
     QMenu* contextMenu;
     QAction* helpOnSelectionAction;
     QAction* cutAction;

--- a/modules/gui/src/include/NelsonPalette.hpp
+++ b/modules/gui/src/include/NelsonPalette.hpp
@@ -31,7 +31,7 @@
 namespace Nelson {
 //===================================================================================
 NLSGUI_IMPEXP void
-createNelsonPalette(QPalette qDefaultPalette);
+createNelsonPalette();
 //===================================================================================
 NLSGUI_IMPEXP bool
 isDarkPalette();

--- a/modules/help_browser/src/c/nlsHelp_browser.vcxproj
+++ b/modules/help_browser/src/c/nlsHelp_browser.vcxproj
@@ -143,6 +143,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -168,6 +169,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -195,6 +197,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -224,6 +227,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/qml_engine/src/c/nlsQml_engine.vcxproj
+++ b/modules/qml_engine/src/c/nlsQml_engine.vcxproj
@@ -99,6 +99,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -119,6 +120,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,6 +143,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -165,6 +168,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/modules/text_editor/src/c/nlsText_editor.vcxproj
+++ b/modules/text_editor/src/c/nlsText_editor.vcxproj
@@ -258,6 +258,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -283,6 +284,7 @@
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -310,6 +312,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -339,6 +342,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Qt 5 & 6 do not detect or manage correctly dark theme on all platforms ...
- on Windows, we apply a dark theme.
- on MacOS, no problems
- on Linux, it depends of qt version and platform 