### PR TITLE
Enable GitHub code scanning using the CodeQL engine

### DIFF
--- a/.github/workflows/codeql-analysis-cpp.yml
+++ b/.github/workflows/codeql-analysis-cpp.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'javascript', 'python' ]
+        language: [ 'cpp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/codeql-analysis-cpp.yml
+++ b/.github/workflows/codeql-analysis-cpp.yml
@@ -1,4 +1,4 @@
-name: "CodeQL analysis"
+name: "CodeQL analysis (C/C++)"
 
 on:
   push:

--- a/.github/workflows/codeql-analysis-javascript-python.yml
+++ b/.github/workflows/codeql-analysis-javascript-python.yml
@@ -1,0 +1,37 @@
+name: "CodeQL analysis"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis-javascript-python.yml
+++ b/.github/workflows/codeql-analysis-javascript-python.yml
@@ -1,4 +1,4 @@
-name: "CodeQL analysis"
+name: "CodeQL analysis (JavaScript+Python)"
 
 on:
   push:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,47 @@
+name: "CodeQL analysis"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y install apt-transport-https ca-certificates gnupg software-properties-common wget ninja-build xvfb libopenmpi-dev autotools-dev libtool automake openmpi-bin gettext pkg-config libffi-dev libicu-dev libxml2-dev liblapack-dev liblapacke-dev fftw3 fftw3-dev libasound-dev portaudio19-dev libsndfile1-dev libtag1-dev alsa-utils libslicot-dev libsqlite3-dev libgl-dev hdf5-tools zlib1g-dev libcurl4-openssl-dev libgit2-dev libboost-all-dev libeigen3-dev libhdf5-dev libmatio-dev qt6-base-dev libqt6svg6-dev qt6-declarative-dev qt6-documentation-tools qml6-module-qtquick qml6-module-qtquick-templates qml6-module-qtquick-controls qml6-module-qtquick-window qml6-module-qtquick-dialogs qml6-module-qtqml-workerscript qml6-module-qtquick-layouts assistant-qt6 qt6-tools-dev
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,10 +38,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt -y install apt-transport-https ca-certificates gnupg software-properties-common wget ninja-build xvfb libopenmpi-dev autotools-dev libtool automake openmpi-bin gettext pkg-config libffi-dev libicu-dev libxml2-dev liblapack-dev liblapacke-dev fftw3 fftw3-dev libasound-dev portaudio19-dev libsndfile1-dev libtag1-dev alsa-utils libslicot-dev libsqlite3-dev libgl-dev hdf5-tools zlib1g-dev libcurl4-openssl-dev libgit2-dev libboost-all-dev libeigen3-dev libhdf5-dev libmatio-dev qt6-base-dev libqt6svg6-dev qt6-declarative-dev qt6-documentation-tools qml6-module-qtquick qml6-module-qtquick-templates qml6-module-qtquick-controls qml6-module-qtquick-window qml6-module-qtquick-dialogs qml6-module-qtqml-workerscript qml6-module-qtquick-layouts assistant-qt6 qt6-tools-dev
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+   
+    # Build the bit of source code that we want to see analysed
+    - name: Build
+      run: |    
+        cmake -DCMAKE_BUILD_TYPE=Release -DQTDIR="/usr/lib/qt6" -G "Ninja" .
+        cmake --build . -- -j $(nproc)
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Enables GitHub code scanning using the CodeQL engine to eventually replace LGTM.com analysis

### What was a problem?

The Nelson code base is now using QT 5.15 / 6, which is causing some challenges with the LGTM.com code analysis — see https://github.com/Nelson-numerical-software/nelson/pull/656#issuecomment-1141445077.

### How this Pull Request fixes the problem?

This PR adds an Action workflow file that enables GitHub code scanning using the CodeQL analysis engine. That's the same analysis engine that powers LGTM.com — it's now been [natively integrated into GitHub](https://github.blog/2020-09-30-code-scanning-is-now-available/) (by the same team that built LGTM).

### Additional Comments (if any)

I've taken the list of dependencies from [this other Actions workflow file](https://github.com/Nelson-numerical-software/nelson/blob/3c4a629017ec8204e45e983ddc564fe8f79dfd06/.github/workflows/ccpp.yml#L269). After a few tweaks, the compilation is now working, and the analysis is running.

I've split out the analysis into two workflows:
 - C/C++ analysis (which requires `apt` dependencies to be installed and `cmake` to be run)
 - JavaScript+Python analysis (which don't require any dependencies/build)