### PR TITLE
Temporarily revert to old CodeQL version

### DIFF
--- a/.github/workflows/codeql-analysis-cpp.yml
+++ b/.github/workflows/codeql-analysis-cpp.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20220728/codeql-bundle-linux64.tar.gz        
+          tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20220825/codeql-bundle-linux64.tar.gz        
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 

--- a/.github/workflows/codeql-analysis-cpp.yml
+++ b/.github/workflows/codeql-analysis-cpp.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
+          tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20220728/codeql-bundle-linux64.tar.gz        
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 


### PR DESCRIPTION
### What was a problem?

https://github.com/github/codeql/issues/10194

### How this Pull Request fixes the problem?

Switch to the 2.10.4 (pre-release) version of CodeQL , which includes https://github.com/github/codeql/pull/10128


@Nelson-numerical-software 
